### PR TITLE
Updated credentials are not saved

### DIFF
--- a/gmail/quickstart/quickstart.py
+++ b/gmail/quickstart/quickstart.py
@@ -38,6 +38,7 @@ def main():
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
+            pickle.dump(creds, token)
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)


### PR DESCRIPTION
After using a refresh token the newly acquired access token and expiration time should be saved for reuse.