### PR TITLE
Fix various errors in Python example for Apps Script execution API

### DIFF
--- a/apps_script/execute/execute.py
+++ b/apps_script/execute/execute.py
@@ -24,14 +24,17 @@ def main():
     """
     SCRIPT_ID = 'ENTER_YOUR_SCRIPT_ID_HERE'
 
-    # Setup the Apps Script API
-    SCOPES = 'https://www.googleapis.com/auth/script.projects'
+    # Set up the Apps Script API
+    SCOPES = [
+        'https://www.googleapis.com/auth/script.scriptapp',
+        'https://www.googleapis.com/auth/drive.readonly',
+    ]
     store = oauth_file.Storage('token.json')
     creds = store.get()
     if not creds or creds.invalid:
         flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
         creds = tools.run_flow(flow, store)
-    service = build('script', 'v1', http=creds.authorize(Http()))
+    service = build('script', 'v1', credentials=creds)
 
     # Create an execution request object.
     request = {"function": "getFoldersUnderRoot"}
@@ -67,7 +70,7 @@ def main():
                 print('No folders returned!')
             else:
                 print('Folders under your root folder:')
-                for (folderId, folder) in folderSet.iteritems():
+                for (folderId, folder) in folderSet.items():
                     print("\t{0} ({1})".format(folder, folderId))
 
     except errors.HttpError as e:


### PR DESCRIPTION
A few things:

 * `dict.iteritems` is obsolete Python 2 syntax. `dict.items` will work in 2 and 3 and for an example the difference in Python 2 is meaningless.
 * The currently-listed scope is wrong and gives error 403 "Request had insufficient authentication scopes." I picked a likely looking one from the list in [the documentation](https://developers.google.com/apps-script/api/reference/rest/v1/scripts/run#authorization-scopes); this works.
 * The example is also missing the drive scope, which is needed with the target script (again, as-is the user will get an error about the drive scope)
 * The Apps Script discovery doc endpoint returns 400 if you give it a token; see [this StackOverflow question](https://stackoverflow.com/questions/54838256/google-app-script-api-cannot-authenticate-request-contains-an-invalid-argument) and [this github issue](https://github.com/googleapis/google-api-python-client/issues/628). This update, noted on SO, uses gapic in a more idiomatic fashion, and works fine. (Of course, oauth2client is deprecated; but I guess addressing that is future work...)