### PR TITLE
for python 3.7+ when refreshing an expired, it is required to pass th…

### DIFF
--- a/drive/quickstart/quickstart.py
+++ b/drive/quickstart/quickstart.py
@@ -16,6 +16,8 @@
 from __future__ import print_function
 import pickle
 import os.path
+import httplib2
+
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
@@ -37,7 +39,7 @@ def main():
     # If there are no (valid) credentials available, let the user log in.
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
+            creds.refresh(Request(httplib2.Http()))
         else:
             flow = InstalledAppFlow.from_client_secrets_file(
                 'credentials.json', SCOPES)


### PR DESCRIPTION
for python 3.7+ when refreshing an expired, it is required to pass the httplib2 as a parameter for the Request on line 42

posted again, because the last one got stucked on Travis