### PR TITLE
docs: change “create gmail api client” to “create drive api client” 

### DIFF
--- a/drive/snippets/drive-v3/file_snippet/upload_to_folder.py
+++ b/drive/snippets/drive-v3/file_snippet/upload_to_folder.py
@@ -35,7 +35,7 @@ def upload_to_folder(real_folder_id):
     creds, _ = google.auth.default()
 
     try:
-        # create gmail api client
+        # create drive api client
         service = build('drive', 'v3', credentials=creds)
 
         folder_id = real_folder_id


### PR DESCRIPTION
docs: change “create gmail api client” to “create drive api client”

The comment mentioned the wrong type of api client to create