### PR TITLE
Fix: Remove extra quote in Slides sample docstring

### DIFF
--- a/slides/snippets/slides_copy_presentation.py
+++ b/slides/snippets/slides_copy_presentation.py
@@ -27,7 +27,7 @@ def copy_presentation(presentation_id, copy_title):
            Creates the copy Presentation the user has access to.
            Load pre-authorized user credentials from the environment.
            TODO(developer) - See https://developers.google.com/identity
-           for guides on implementing OAuth2 for the application.\n"
+           for guides on implementing OAuth2 for the application.
            """
 
     creds, _ = google.auth.default()

--- a/slides/snippets/slides_create_bulleted_text.py
+++ b/slides/snippets/slides_create_bulleted_text.py
@@ -27,7 +27,7 @@ def create_bulleted_text(presentation_id, shape_id):
         Run create_bulleted_text the user has access to.
         Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity
-        for guides on implementing OAuth2 for the application.\n"
+        for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_create_image.py
+++ b/slides/snippets/slides_create_image.py
@@ -27,7 +27,7 @@ def create_image(presentation_id, page_id):
         Creates images the user has access to.
         Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity
-        for guides on implementing OAuth2 for the application.\n"
+        for guides on implementing OAuth2 for the application.
         """
 
     creds, _ = google.auth.default()

--- a/slides/snippets/slides_create_presentation.py
+++ b/slides/snippets/slides_create_presentation.py
@@ -27,7 +27,7 @@ def create_presentation(title):
         Creates the Presentation the user has access to.
         Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity
-        for guides on implementing OAuth2 for the application.\n"
+        for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_create_sheets_chart.py
+++ b/slides/snippets/slides_create_sheets_chart.py
@@ -28,7 +28,7 @@ def create_sheets_chart(presentation_id, page_id, spreadsheet_id,
     create_sheets_chart the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_create_sheets_chart.py
+++ b/slides/snippets/slides_create_sheets_chart.py
@@ -90,3 +90,5 @@ if __name__ == '__main__':
                         "FIRSTSLIDE",
                         "17eqFZl_WK4WVixX8PjvjfLD77DraoFwMDXeiHB3dvuM",
                         "1107320627")
+
+# [END slides_create_sheets_chart]

--- a/slides/snippets/slides_create_slide.py
+++ b/slides/snippets/slides_create_slide.py
@@ -27,7 +27,7 @@ def create_slide(presentation_id, page_id):
     Creates the Presentation the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.\n
     """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_create_textbox_with_text.py
+++ b/slides/snippets/slides_create_textbox_with_text.py
@@ -27,7 +27,7 @@ def create_textbox_with_text(presentation_id, page_id):
     Creates the textbox with text, the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_refresh_sheets_chart.py
+++ b/slides/snippets/slides_refresh_sheets_chart.py
@@ -27,7 +27,7 @@ def refresh_sheets_chart(presentation_id, presentation_chart_id):
         refresh_sheets_chart the user has access to.
         Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity
-        for guides on implementing OAuth2 for the application.\n"
+        for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_simple_text_replace.py
+++ b/slides/snippets/slides_simple_text_replace.py
@@ -27,7 +27,7 @@ def simple_text_replace(presentation_id, shape_id, replacement_text):
     Run simple_text_replace the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_simple_text_replace.py
+++ b/slides/snippets/slides_simple_text_replace.py
@@ -70,3 +70,5 @@ if __name__ == '__main__':
     simple_text_replace('10QnVUx1X2qHsL17WUidGpPh_SQhXYx40CgIxaKk8jU4',
                         'MyTextBox_6',
                         'GWSpace_now')
+
+# [END slides_simple_text_replace]

--- a/slides/snippets/slides_text_merging.py
+++ b/slides/snippets/slides_text_merging.py
@@ -27,7 +27,7 @@ def text_merging(template_presentation_id, data_spreadsheet_id):
     Run Text merging the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/slides/snippets/slides_text_style_update.py
+++ b/slides/snippets/slides_text_style_update.py
@@ -27,7 +27,7 @@ def text_style_update(presentation_id, shape_id):
     create_sheets_chart the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member


### PR DESCRIPTION
 There's an extra quote in the docstring, causing the code snippet to not be rendered with correct syntax highlighting.

If you go to this page, the snippet look like it's all commented out.
https://developers.google.com/slides/api/guides/create-slide#python

<img width="897" alt="Screen Shot 2022-07-03 at 12 46 05 PM" src="https://user-images.githubusercontent.com/5844587/177055059-722269e2-3f51-4259-bdf6-77909938dda2.png">

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes internal issue # 237935769

## Has it been tested?
- [ ] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
