### PR TITLE
fix: typo in the comment gmail -> drive

### DIFF
--- a/drive/snippets/drive-v3/drive_snippet/create_drive.py
+++ b/drive/snippets/drive-v3/drive_snippet/create_drive.py
@@ -36,7 +36,7 @@ def create_drive():
     creds, _ = google.auth.default()
 
     try:
-        # create gmail api client
+        # create drive api client
         service = build('drive', 'v3', credentials=creds)
 
         drive_metadata = {'name': 'Project Resources'}


### PR DESCRIPTION
There is a typo on the comment where we say we want to create a gmail api client while we are actually trying to create a drive api client.

# Description

Fixing a small typo in the comment

Fixes # (issue)

## Has it been tested?
- [x] Development testing done
- [x] Unit or integration test implemented

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have performed a peer-reviewed with team member(s)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
