### PR TITLE
#336 use the with_subject method

### DIFF
--- a/gmail/snippet/settings snippets/update_signature.py
+++ b/gmail/snippet/settings snippets/update_signature.py
@@ -30,7 +30,8 @@ def update_signature():
     for guides on implementing OAuth2 for the application.
     """
     creds, _ = google.auth.default()
-
+    # If you want to use service account to impersonate a user account
+    # creds = creds.with_subject('user@yourdomain.com')
     try:
         # create gmail api client
         service = build('gmail', 'v1', credentials=creds)


### PR DESCRIPTION
# Description

If you have delegated domain-wide access to the service account and you want to impersonate a user account, use the with_subject method of an existing ServiceAccountCredentials object. This is to resolve #336.

Fixes # (issue)

## Has it been tested?
- [ ] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
