### PR TITLE
Fix: Remove extra quote in Sample docstrings

### DIFF
--- a/classroom/snippets/classroom_all_submissions.py
+++ b/classroom/snippets/classroom_all_submissions.py
@@ -28,7 +28,7 @@ def classroom_all_submissions(course_id, user_id):
     Creates the list of all submissions of the courses the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
 
     creds, _ = google.auth.default()

--- a/classroom/snippets/classroom_create_coursework.py
+++ b/classroom/snippets/classroom_create_coursework.py
@@ -28,7 +28,7 @@ def classroom_create_coursework(course_id):
     Creates the coursework the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
 
     creds, _ = google.auth.default()

--- a/classroom/snippets/classroom_invite_guardian.py
+++ b/classroom/snippets/classroom_invite_guardian.py
@@ -28,7 +28,7 @@ def classroom_invite_guardian():
     Creates the courses the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
 
     creds, _ = google.auth.default()

--- a/classroom/snippets/classroom_list_student_submissions.py
+++ b/classroom/snippets/classroom_list_student_submissions.py
@@ -27,7 +27,7 @@ def classroom_list_student_submissions(course_id, coursework_id, user_id):
     Creates the courses the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
 
     creds, _ = google.auth.default()

--- a/classroom/snippets/classroom_list_submissions.py
+++ b/classroom/snippets/classroom_list_submissions.py
@@ -27,7 +27,7 @@ def classroom_list_submissions(course_id, coursework_id):
     Creates the courses the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
     """
 
     creds, _ = google.auth.default()

--- a/sheets/snippets/sheets_append_values.py
+++ b/sheets/snippets/sheets_append_values.py
@@ -28,7 +28,7 @@ def append_values(spreadsheet_id, range_name, value_input_option,
     Creates the batch_update the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_batch_get_values.py
+++ b/sheets/snippets/sheets_batch_get_values.py
@@ -27,7 +27,7 @@ def batch_get_values(spreadsheet_id, _range_names):
     Creates the batch_update the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_batch_update_values.py
+++ b/sheets/snippets/sheets_batch_update_values.py
@@ -28,7 +28,7 @@ def batch_update_values(spreadsheet_id, range_name,
         Creates the batch_update the user has access to.
         Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity
-        for guides on implementing OAuth2 for the application.\n"
+        for guides on implementing OAuth2 for the application.
             """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_conditional_formatting.py
+++ b/sheets/snippets/sheets_conditional_formatting.py
@@ -27,7 +27,7 @@ def conditional_formatting(spreadsheet_id):
     Creates the batch_update the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_create.py
+++ b/sheets/snippets/sheets_create.py
@@ -27,7 +27,7 @@ def create(title):
     Creates the Sheet the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_filter_views.py
+++ b/sheets/snippets/sheets_filter_views.py
@@ -27,7 +27,7 @@ def filter_views(spreadsheet_id):
         Creates the batch_update the user has access to.
         Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity
-        for guides on implementing OAuth2 for the application.\n"
+        for guides on implementing OAuth2 for the application.
             """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_get_values.py
+++ b/sheets/snippets/sheets_get_values.py
@@ -27,7 +27,7 @@ def get_values(spreadsheet_id, range_name):
     Creates the batch_update the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_pivot_tables.py
+++ b/sheets/snippets/sheets_pivot_tables.py
@@ -27,7 +27,7 @@ def pivot_tables(spreadsheet_id):
     Creates the batch_update the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member

--- a/sheets/snippets/sheets_update_values.py
+++ b/sheets/snippets/sheets_update_values.py
@@ -28,7 +28,7 @@ def update_values(spreadsheet_id, range_name, value_input_option,
     Creates the batch_update the user has access to.
     Load pre-authorized user credentials from the environment.
     TODO(developer) - See https://developers.google.com/identity
-    for guides on implementing OAuth2 for the application.\n"
+    for guides on implementing OAuth2 for the application.
         """
     creds, _ = google.auth.default()
     # pylint: disable=maybe-no-member


### PR DESCRIPTION


# Description

There's an extra quote at the end of docstrings, causing the docs to not be rendered correctly.
They look like commented code.

Removing the trailing \n" will fix the rendering.

Example, if you go to this page: https://developers.google.com/sheets/api/guides/filters

The code looks like comments instead of code.

![Screen Shot 2022-07-27 at 2 48 26 PM](https://user-images.githubusercontent.com/5844587/181378543-42ea28c0-e14d-4424-ba93-4d283e70290a.png)

Fixes # (issue)

## Has it been tested?
- [ ] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
