### PR TITLE
fix typo: key specifying the name of the folder

### DIFF
--- a/drive/snippets/drive-v3/file_snippet/create_folder.py
+++ b/drive/snippets/drive-v3/file_snippet/create_folder.py
@@ -36,7 +36,7 @@ def create_folder():
         # create drive api client
         service = build('drive', 'v3', credentials=creds)
         file_metadata = {
-            'title': 'Invoices',
+            'name': 'Invoices',
             'mimeType': 'application/vnd.google-apps.folder'
         }
 


### PR DESCRIPTION
# Description

The string in the key specifying the folder name is 'name', not 'title'

Fixes #339 

## Has it been tested?
- [X] Development testing done
- [X] Unit or integration test implemented

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have performed a peer-reviewed with team member(s)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
