### PR TITLE
Update incorrect comment

### DIFF
--- a/forms/snippets/retrieve_contents.py
+++ b/forms/snippets/retrieve_contents.py
@@ -30,7 +30,7 @@ if not creds or creds.invalid:
 service = discovery.build('forms', 'v1', http=creds.authorize(
     Http()), discoveryServiceUrl=DISCOVERY_DOC, static_discovery=False)
 
-# Prints the title of the sample form:
+# Prints the contents of the sample form:
 form_id = '<YOUR_FORM_ID>'
 result = service.forms().get(formId=form_id).execute()
 print(result)


### PR DESCRIPTION
- the code below prints all contents of the form instead of the title

# Description

The comment is in correct. The code below does not print the title of form. Instead it prints the full contents of the form. 

Fixes # (issue)

## Has it been tested?
- [ x ] Development testing done
- [ x ] Unit or integration test implemented

## Checklist

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have performed a peer-reviewed with team member(s)
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published in downstream modules
