### PR TITLE
Update export_pdf.py

### DIFF
--- a/drive/snippets/drive-v3/file_snippet/export_pdf.py
+++ b/drive/snippets/drive-v3/file_snippet/export_pdf.py
@@ -55,7 +55,7 @@ def export_pdf(real_file_id):
 
     except HttpError as error:
         print(F'An error occurred: {error}')
-        file = None
+        return None
 
     return file.getvalue()
 


### PR DESCRIPTION
In case the error is triggered, file will be None. The resulting return value will throw an error at the .getvalue() method is called, since the None type does not contain it.