### PR TITLE
Update quickstart.py with credentials.json

### DIFF
--- a/forms/quickstart/quickstart.py
+++ b/forms/quickstart/quickstart.py
@@ -25,7 +25,7 @@ DISCOVERY_DOC = "https://forms.googleapis.com/$discovery/rest?version=v1"
 store = file.Storage('token.json')
 creds = None
 if not creds or creds.invalid:
-    flow = client.flow_from_clientsecrets('client_secrets.json', SCOPES)
+    flow = client.flow_from_clientsecrets('credentials.json', SCOPES)
     creds = tools.run_flow(flow, store)
 
 form_service = discovery.build('forms', 'v1', http=creds.authorize(


### PR DESCRIPTION

# Description

Docs in [Forms API Docs](https://developers.google.com/forms/api/quickstart/python?hl=pt-br) mention **credentials.json** instead of **client_secrets.json**

Simple change in file name, not necessary to test.

Fixes # (issue)

## Has it been tested?
- [ ] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
