### PR TITLE
fix: file content can't be set when main_type is 'text', 'image', or …

### DIFF
--- a/gmail/snippet/send mail/create_draft_with_attachment.py
+++ b/gmail/snippet/send mail/create_draft_with_attachment.py
@@ -96,14 +96,14 @@ def build_file_part(file):
     content_type = "application/octet-stream"
   main_type, sub_type = content_type.split("/", 1)
   if main_type == "text":
-    with open(file, "rb"):
-      msg = MIMEText("r", _subtype=sub_type)
+    with open(file, "r") as f:
+      msg = MIMEText(f.read(), _subtype=sub_type)
   elif main_type == "image":
-    with open(file, "rb"):
-      msg = MIMEImage("r", _subtype=sub_type)
+    with open(file, "rb") as f:
+      msg = MIMEImage(f.read(), _subtype=sub_type)
   elif main_type == "audio":
-    with open(file, "rb"):
-      msg = MIMEAudio("r", _subtype=sub_type)
+    with open(file, "rb") as f:
+      msg = MIMEAudio(f.read(), _subtype=sub_type)
   else:
     with open(file, "rb"):
       msg = MIMEBase(main_type, sub_type)


### PR DESCRIPTION
fix attachment bug sending emails

# Description

I found that the attachment I sent in the email only contains a single string "r". I later realized that the code did not read the file content, but instead wrote a default "r".

Fixes # (issue)

## Has it been tested?
- [x] Development testing done
- [x] Unit or integration test implemented

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have performed a peer-reviewed with team member(s)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
