### PR TITLE
[Bugfix] Wrong ISO time format in Python quickstart for Calendar API

### DIFF
--- a/calendar/quickstart/quickstart.py
+++ b/calendar/quickstart/quickstart.py
@@ -53,7 +53,7 @@ def main():
     service = build("calendar", "v3", credentials=creds)
 
     # Call the Calendar API
-    now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat() + "Z"  # 'Z' indicates UTC time
+    now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     print("Getting the upcoming 10 events")
     events_result = (
         service.events()


### PR DESCRIPTION
Hi team,

issue #2115 

While testing the Calendar API using the [Python quickstart guide](https://developers.google.com/workspace/calendar/api/quickstart/python?hl=en), I noticed an issue in the time formatting line.

The current code is:

```python
now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat() + "Z"  # 'Z' indicates UTC time
```
However, this results in an invalid ISO 8601 timestamp like:

makefile
```
2025-04-07T14:39:12.345678+00:00Z
```
Appending "Z" after a timezone-aware ISO string (which already includes +00:00) makes the timestamp invalid. This can cause unexpected errors when calling the API.

It should be corrected to:

```python
now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
```
When the incorrect format is used, it leads to errors like this:

```json
{
  "error": {
    "code": 403,
    "message": "Method doesn't allow unregistered callers (callers without established identity)...",
    "status": "PERMISSION_DENIED"
  }
}
```
Thanks!

