### PR TITLE
fix: correct time format in Python quickstart

### DIFF
--- a/calendar/quickstart/quickstart.py
+++ b/calendar/quickstart/quickstart.py
@@ -53,7 +53,7 @@ def main():
     service = build("calendar", "v3", credentials=creds)
 
     # Call the Calendar API
-    now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat() + "Z"  # 'Z' indicates UTC time
+    now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
     print("Getting the upcoming 10 events")
     events_result = (
         service.events()


### PR DESCRIPTION
# Description
While testing the Calendar API using the [Python quickstart guide](https://developers.google.com/workspace/calendar/api/quickstart/python?hl=en), I noticed that the time formatting line appends a "Z" to a timezone-aware ISO string. This leads to an invalid ISO 8601 timestamp such as:

```
2025-04-07T14:39:12.345678+00:00Z
```
Appending "Z" to a string that already contains +00:00 (UTC offset) makes it invalid and may result in errors when calling the API.

### Fix
Updated the time formatting line to remove the redundant "Z":

```python
now = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
```
This ensures the timestamp remains valid and conforms to ISO 8601.

Fixes #2115

## Has it been tested?
- [x] Development testing done
- [ ] Unit or integration test implemented

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have performed a peer-reviewed with team member(s)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
