### PR TITLE
feat: Add scripts for sections and section items with user credentials

### DIFF
--- a/chat/client-libraries/cloud/create_section_user_cred.py
+++ b/chat/client-libraries/cloud/create_section_user_cred.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_create_section_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections"]
+
+# This sample shows how to create a section of type CUSTOM_SECTION with
+# user credential for a human user
+def create_section_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    section = chat_v1.Section()
+    # Replace DISPLAY_NAME here
+    section.display_name = "SECTION_DISPLAY_NAME"
+    section.type_ = "CUSTOM_SECTION"
+
+    request = chat_v1.CreateSectionRequest(
+        parent="users/me",
+        section=section,
+    )
+
+    # Make the request
+    response = client.create_section(request)
+
+    # Handle the response
+    print(response)
+
+create_section_with_user_cred()
+# [END chat_create_section_user_cred]

--- a/chat/client-libraries/cloud/delete_section_user_cred.py
+++ b/chat/client-libraries/cloud/delete_section_user_cred.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_delete_section_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections"]
+
+# This sample shows how to delete a section with user credential for a
+# human user
+def delete_section_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    request = chat_v1.DeleteSectionRequest(
+        # Replace SECTION_NAME here.
+        name="SECTION_NAME"
+    )
+
+    # Make the request
+    response = client.delete_section(request)
+
+    # Handle the response
+    print(response)
+
+delete_section_with_user_cred()
+# [END chat_delete_section_user_cred]

--- a/chat/client-libraries/cloud/list_section_items_user_cred.py
+++ b/chat/client-libraries/cloud/list_section_items_user_cred.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_list_section_items_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections.readonly"]
+
+# This sample shows how to list section items with user credential for a human
+# user
+def list_section_items_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    request = chat_v1.ListSectionItemsRequest(
+        # Replace SECTION_NAME here
+        parent="SECTION_NAME",
+        # Number of results that will be returned at once
+        page_size=10
+    )
+
+    # Make the request
+    page_result = client.list_section_items(request)
+
+    # Handle the response. Iterating over page_result will yield results and
+    # resolve additional pages automatically.
+    for item in page_result:
+        print(item)
+
+list_section_items_with_user_cred()
+# [END chat_list_section_items_user_cred]

--- a/chat/client-libraries/cloud/list_sections_user_cred.py
+++ b/chat/client-libraries/cloud/list_sections_user_cred.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_list_sections_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections.readonly"]
+
+# This sample shows how to list sections with user credential for a human user
+def list_sections_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    request = chat_v1.ListSectionsRequest(
+        parent="users/me",
+        # Number of results that will be returned at once
+        page_size=10
+    )
+
+    # Make the request
+    page_result = client.list_sections(request)
+
+    # Handle the response. Iterating over page_result will yield results and
+    # resolve additional pages automatically.
+    for section in page_result:
+        print(section)
+
+list_sections_with_user_cred()
+# [END chat_list_sections_user_cred]

--- a/chat/client-libraries/cloud/move_section_item_user_cred.py
+++ b/chat/client-libraries/cloud/move_section_item_user_cred.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_move_section_item_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections"]
+
+# This sample shows how to move a section item with user credential for a human
+# user
+def move_section_item_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    request = chat_v1.MoveSectionItemRequest(
+        # Replace SECTION_ITEM_NAME here
+        name="SECTION_ITEM_NAME",
+        # Replace TARGET_SECTION_NAME here
+        target_section="TARGET_SECTION_NAME"
+    )
+
+    # Make the request
+    response = client.move_section_item(request)
+
+    # Handle the response
+    print(response)
+
+move_section_item_with_user_cred()
+# [END chat_move_section_item_user_cred]

--- a/chat/client-libraries/cloud/position_section_user_cred.py
+++ b/chat/client-libraries/cloud/position_section_user_cred.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_position_section_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections"]
+
+# This sample shows how to update a sort order of a section with user
+# credential for a human user
+def position_section_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    request = chat_v1.PositionSectionRequest(
+        # Replace USER and SECTION here
+        name="users/USER/sections/SECTION",
+        # Replace SORT_ORDER here
+        sort_order=SORT_ORDER,
+        # Also supports:
+        #   relative_position="START"
+        #   relative_position="END"
+    )
+
+    # Make the request
+    response = client.position_section(request)
+
+    # Handle the response
+    print(response)
+
+position_section_with_user_cred()
+# [END chat_position_section_user_cred]

--- a/chat/client-libraries/cloud/update_section_user_cred.py
+++ b/chat/client-libraries/cloud/update_section_user_cred.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-apps-chat
+
+
+# [START chat_update_section_user_cred]
+from authentication_utils import create_client_with_user_credentials
+from google.apps import chat_v1 as google_chat
+
+SCOPES = ["https://www.googleapis.com/auth/chat.users.sections"]
+
+# This sample shows how to update a display name of a section with user
+# credential for a human user
+def update_section_with_user_cred():
+    # Create a client
+    client = create_client_with_user_credentials(SCOPES)
+
+    # Initialize request argument(s)
+    request = chat_v1.UpdateSectionRequest(
+        section={
+            # Replace USER and SECTION here
+            "name": "users/USER/sections/SECTION",
+            # Replace DISPLAY_NAME here
+            "display_name": "DISPLAY_NAME"
+        },
+        update_mask="displayName"
+    )
+
+    # Make the request
+    response = client.update_section(request)
+
+    # Handle the response
+    print(response)
+
+update_section_with_user_cred()
+# [END chat_update_section_user_cred]


### PR DESCRIPTION
# Description

Add scripts for [sections](https://developers.google.com/workspace/chat/api/reference/rest/v1/users.sections) and [section items](https://developers.google.com/workspace/chat/api/reference/rest/v1/users.sections.items) with user credentials:
- `create_section_user_cred.py`
- `delete_section_user_cred.py`
- `update_section_user_cred.py`
- `position_section_user_cred.py`
- `list_sections_user_cred.py`
- `list_section_items_user_cred.py`
- `move_section_items_user_cred.py`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have performed a peer-reviewed with team member(s)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
